### PR TITLE
fix: dangling-else made email quoted-string checks unreachable

### DIFF
--- a/shared/src/main/scala/io/github/jam01/json_schema/vocab/FormatAssertion.scala
+++ b/shared/src/main/scala/io/github/jam01/json_schema/vocab/FormatAssertion.scala
@@ -210,12 +210,13 @@ object FormatAssertion extends VocabFactory[FormatAssertion] {
         if (!i18n && !between(c, ' ', '~')) return false              // must be printable
         if (i18n && isAscii(c) && !between(c, ' ', '~')) return false // must be printable or non-ASCII
 
-        if (c == '"' && i != qstr.length - 1)           // if DQUOTE in the middle
-          if (qstr.charAt(i - 1) != '\\') return false  //   preceding char must be a backslash
-        else if (c == '\\' && i == qstr.length - 2)     // if backslash at end of quoted-string
-          if (qstr.charAt(i - 1) != '\\') return false  //   preceding char must be a backslash
-        else if (i18n && !isAscii(c))                   // if non-ASCII
-          if (qstr.charAt(i - 1) == '\\') return false  //   preceding char must not be a backslash
+        if (c == '"' && i != qstr.length - 1) {                  // if DQUOTE in the middle
+          if (qstr.charAt(i - 1) != '\\') return false           //   preceding char must be a backslash
+        } else if (c == '\\' && i == qstr.length - 2) {          // if backslash at end of quoted-string
+          if (qstr.charAt(i - 1) != '\\') return false           //   preceding char must be a backslash
+        } else if (i18n && !isAscii(c)) {                        // if non-ASCII
+          if (qstr.charAt(i - 1) == '\\') return false           //   preceding char must not be a backslash
+        }
 
         i += 1
       }

--- a/shared/src/test/scala/io/github/jam01/json_schema/FormatAssertionTest.scala
+++ b/shared/src/test/scala/io/github/jam01/json_schema/FormatAssertionTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Jose Montoya
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.github.jam01.json_schema
+
+import org.junit.jupiter.api.Assertions.{assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
+
+class FormatAssertionTest {
+  private def validate(format: String, value: String): Boolean = {
+    val sch = ujson.Readable
+      .fromString(s"""{"format":"$format"}""")
+      .transform(SchemaR())
+    try ujson.Str(value).transform(validator(sch, Config(dialect = Dialect.FormatAssertion))).vvalid
+    catch { case e: ValidationException => e.result.vvalid }
+  }
+
+  // email — quoted-string local part
+  @Test def email_quoted_space_valid(): Unit =
+    assertTrue(validate("email", "\"joe bloggs\"@example.com"))
+
+  @Test def email_quoted_escaped_dquote_valid(): Unit =
+    assertTrue(validate("email", "\"a\\\"b\"@example.com"))
+
+  @Test def email_quoted_unescaped_dquote_invalid(): Unit =
+    assertFalse(validate("email", "\"a\"b\"@example.com"))
+
+  // regression: dangling-else made the backslash-at-end check unreachable, so a
+  // trailing `\"` (which escapes the closing quote, leaving the string unterminated)
+  // was silently accepted.
+  @Test def email_quoted_unescaped_trailing_backslash_invalid(): Unit =
+    assertFalse(validate("email", "\"abc\\\"@example.com"))
+
+  @Test def email_quoted_escaped_trailing_backslash_valid(): Unit =
+    assertTrue(validate("email", "\"abc\\\\\"@example.com"))
+
+  // regression: i18n branch (non-ASCII preceded by backslash) was also unreachable.
+  @Test def idn_email_quoted_backslash_before_nonascii_invalid(): Unit =
+    assertFalse(validate("idn-email", "\"\\é\"@example.com"))
+
+  @Test def idn_email_quoted_bare_nonascii_valid(): Unit =
+    assertTrue(validate("idn-email", "\"é\"@example.com"))
+}


### PR DESCRIPTION
The `if/else if/else if` chain over `c` in isEmail's quoted-string loop was indented to look like character dispatch but actually bound the inner `if (preceding != '\')` to the outer's `else` branches. Only the first arm — "DQUOTE in the middle" — fired; the "backslash at end of quoted-string" and "i18n non-ASCII after backslash" checks were dead.

Effect: emails with a stray trailing `\"` (which escapes the closing quote, leaving the string unterminated) were silently accepted, e.g. `"abc\"@example.com`. Same for idn-email with `\<non-ASCII>` quoted pairs.

Add braces to disambiguate, plus FormatAssertionTest with regression and positive-control cases.