### PR TITLE
fix: register inner `$id` schemas under correctly resolved base URI

### DIFF
--- a/shared/src/main/scala/io/github/jam01/json_schema/SchemaR.scala
+++ b/shared/src/main/scala/io/github/jam01/json_schema/SchemaR.scala
@@ -85,7 +85,9 @@ final class SchemaR private(docbase: Uri,
 
     override def visitEnd(index: Int): ObjectSchema = {
       if (parent.isEmpty) {
-        ids.foreach { case (id, sch) => reg.addOne(sch.base.resolve(id), sch) }
+        // `sch.base` already resolves `$id` against the enclosing base, so use it directly —
+        // re-resolving the raw id string would double-append a relative segment.
+        ids.foreach { case (_, sch) => reg.addOne(sch.base, sch) }
         anchors.foreach { case (anchor, isDyn, sch) => reg.addOne(sch.base.withFragment(anchor, isDyn), sch) }
       }
       sch

--- a/shared/src/main/scala/io/github/jam01/json_schema/SchemaR.scala
+++ b/shared/src/main/scala/io/github/jam01/json_schema/SchemaR.scala
@@ -85,8 +85,6 @@ final class SchemaR private(docbase: Uri,
 
     override def visitEnd(index: Int): ObjectSchema = {
       if (parent.isEmpty) {
-        // `sch.base` already resolves `$id` against the enclosing base, so use it directly —
-        // re-resolving the raw id string would double-append a relative segment.
         ids.foreach { case (_, sch) => reg.addOne(sch.base, sch) }
         anchors.foreach { case (anchor, isDyn, sch) => reg.addOne(sch.base.withFragment(anchor, isDyn), sch) }
       }

--- a/shared/src/test/scala/io/github/jam01/json_schema/TestSuiteTest.scala
+++ b/shared/src/test/scala/io/github/jam01/json_schema/TestSuiteTest.scala
@@ -52,10 +52,7 @@ class TestSuiteTest {
 
 object TestSuiteTest {
   val NotSupported: Seq[String] = Seq.empty
-  // refRemote.json — chained `$id` resolution where an inner `$defs.<name>.$id` is a relative ref
-  // (e.g. `"baseUriChangeFolder/"`) is not being registered against the root `$id`'s base, so the
-  // outer `$ref` to that resolved URI fails. Tracked separately.
-  val NotSupportedTests: Seq[String] = Seq("base URI change - change folder", "base URI change - change folder in subschema")
+  val NotSupportedTests: Seq[String] = Seq.empty
   val NotSupportedFormat: Seq[String] = Seq("idn-hostname.json", "idn-email.json")
   val NotSupportedFormatTests: Seq[String] = Seq("weeks cannot be combined with other units")
 


### PR DESCRIPTION
`ObjSchema.base` already resolves `$id` against the enclosing base, so `reg.addOne(sch.base.resolve(id), sch)` was resolving the same id a second time. Absolute `$id`s no-op'd through this, but a relative inner `$id` like `"baseUriChangeFolder/"` got double-appended, registering `.../baseUriChangeFolder/baseUriChangeFolder/` instead of `.../baseUriChangeFolder/` — so the sibling `$ref` lookup missed.

Drops the two refRemote.json cases from `NotSupportedTests`; they now pass through `test_suite` and `error_shape`.