### PR TITLE
feat: support sequential validator reuse

### DIFF
--- a/docs/decisions/007-validator-reuse.md
+++ b/docs/decisions/007-validator-reuse.md
@@ -1,0 +1,64 @@
+---
+date: 2026-05-13
+---
+# How should the validator handle sequential reuse and document its concurrency contract?
+## Context and Problem Statement
+`json_schema.validator(schema, config, registry)` returns a `Visitor[?, OutputUnit]` backed by a single `DefaultContext` that holds per-traversal mutable state: an instance-location stack, an `_pointer` cache, and two maps tracking annotation `dependents`/`dependencies` for keywords like `unevaluatedProperties`/`unevaluatedItems`. The contract was undocumented and, in practice, the visitor was effectively single-shot for two reasons:
+
+1. **`ffast` failures left location state dirty.** When validation fails at the root under `ffast=true`, the top-level visitor throws `ValidationException` from inside `FFastObjectSchemaValidator.compose`. The `tracker.pop` calls in `PointerDelegate.visitValue` that would have unwound the un-traversed remainder of the instance never run, so `insloc` retained the giveup-point tokens. A subsequent `.transform(...)` on the same visitor would prefix every instance-location with those tokens, silently corrupting results.
+2. **`onScopeEnd` removed `dependents` for every ended scope.** Vocab constructors (notably `Unevaluated`) register dependants once, and lazily-resolved `$ref` paths add more on first traversal. Removing them by scope at end-of-scope meant the second traversal had no dependant tracking, so e.g. `unevaluatedProperties:false` falsely rejected previously-known-evaluated keys.
+
+Separately, the root unit's `insLoc` on an `ffast` failure captured `ctx.instanceLoc` at throw time — i.e. wherever traversal gave up — instead of the root, which is what the successful path produces. Reuse aside, this was an internal inconsistency.
+
+No documentation told users about any of this. Concurrent use was simply not supported and not stated.
+
+## Decision Drivers
+* Allow callers to amortize validator construction across many instances (the common shape: "validate a thousand JSON payloads against one schema").
+* Make the concurrency contract explicit.
+* Minimize blast radius — do not redesign the Context API in this change.
+* Preserve the existing single-threaded, sequential-call performance.
+
+## Considered Options
+* (A) Document the visitor as single-shot. No code changes.
+* (B) Sequential reuse via a `reset()` invoked at end of root scope. Document not-thread-safe.
+* (C) Full thread-safety: move per-traversal state out of `DefaultContext` into a state value carried as a parameter through visit methods. Vocab visit signatures change.
+
+## Decision Outcome
+Chosen options: **(A) + (B)**.
+
+`DefaultContext.reset()` clears `insloc`, `_pointer`, and `dependencies` (but **not** `dependents` — see below). It is called from `onScopeEnd` when the ending scope is `JsonPointer.Root`, which covers both the success path and the throw-from-`compose` path because `onScopeEnd` runs before the `ValidationException` is constructed.
+
+`FFastObjectSchemaValidator.compose` was also amended so that, at the root scope (`dynParent.isEmpty`), the composed unit's `insLoc` is unconditionally `JsonPointer.Root` instead of `ctx.instanceLoc`. Under `ffast`, the latter would otherwise point at the give-up location when compose runs mid-traversal during exception propagation.
+
+The scaladoc on `validator(...)` now documents the visitor as **not thread-safe** but **safe for repeated sequential `.transform(...)` calls**, including after `ValidationException`.
+
+### Consequences
+* Single-shot users see no change. Visitor construction is unchanged.
+* Reuse users (the typical batch-validation case) now work correctly — including after `ffast` failures — without needing to rebuild the validator.
+* `dependents` is no longer pruned per-scope; it is bounded by the schema's structure (number of `Unevaluated` sub-schemas plus those reachable via `$ref`), not by traversal count, so the memory cost is fixed for a given schema.
+* `onScopeEnd` for the root scope now also runs `reset()`, which is cheap (one stack clear, one push, one var write, one map clear).
+* Concurrent use across threads remains unsupported. A future change (Option C) would be a substantial API refactor and should be its own decision.
+
+## Pros and Cons of the Options
+### (A) Document single-shot only
+* Cheapest. No code change.
+* Forces every caller into the boilerplate `validator(...)` per instance — wastes the immutable vocab tree construction work on every call.
+* Leaves the latent `insLoc`-on-failure inconsistency unfixed.
+
+### (B) `reset()` at end of root scope
+* Small, surgical change. Two files touched in production code.
+* Fixes a real correctness bug (`unevaluatedProperties` across reuse) that the test suite happened not to exercise — every test-suite case builds a fresh validator.
+* No throughput cost for single-shot users; one cheap reset call at end of each transform.
+* Does not address concurrent use.
+
+### (C) Full thread-safety
+* Required to allow concurrent validation against the same schema from many threads.
+* Touches every Vocab — they currently capture `ctx` at construction; a per-traversal state would need to be threaded through visit methods or stored on the per-call anonymous `ArrVisitor`/`ObjVisitor` returned by `visitArray`/`visitObject`.
+* Annotation-dependency mechanism specifically relies on a Context shared across all sub-vocabs to mediate `offerAnnotation`/`getDependenciesFor` — that would need redesign (e.g. per-traversal state object passed alongside `ctx`).
+* Out of scope for this change; warrants its own ADR.
+
+## More Information
+* `shared/src/main/scala/io/github/jam01/json_schema/Context.scala` — `reset()` is defined here, and `onScopeEnd` no longer removes `dependents`.
+* `shared/src/main/scala/io/github/jam01/json_schema/SchemaValidator.scala` — root-scope `insLoc` fix in `FFastObjectSchemaValidator.compose`.
+* `shared/src/main/scala/io/github/jam01/json_schema/package.scala` — scaladoc on `validator(...)` documents the contract.
+* `shared/src/test/scala/io/github/jam01/json_schema/ValidatorReuseTest.scala` — regression coverage for: `ffast` failure → success, `ffast` failure → failure, repeated transforms involving `unevaluatedProperties`, and non-`ffast` reuse.

--- a/shared/src/main/scala/io/github/jam01/json_schema/Context.scala
+++ b/shared/src/main/scala/io/github/jam01/json_schema/Context.scala
@@ -241,10 +241,27 @@ final class DefaultContext(private val registry: Registry,
   }
 
   override def onScopeEnd(schLocation: JsonPointer, result: OutputUnit): OutputUnit = {
-    dependents.remove(schLocation)
     dependencies.remove(schLocation)
 
     if (!result.vvalid) notifyInvalid(Seq(result))
+    if (schLocation == JsonPointer.Root) reset()
     result
+  }
+
+  /**
+   * Reset per-traversal mutable state so this Context can be reused for a new instance traversal.
+   *
+   * Called automatically at the end of the root scope (`onScopeEnd` with `JsonPointer.Root`),
+   * including the path where a top-level `ffast` failure throws `ValidationException` — without
+   * the reset, the leftover instance-location tokens from the un-traversed remainder of the
+   * instance would corrupt the next `.transform()` on this validator.
+   *
+   * Note that the Context is not safe for concurrent use; reuse is sequential only.
+   */
+  def reset(): Unit = {
+    insloc.clear()
+    insloc.push("")
+    _pointer = JsonPointer.Root
+    dependencies.clear()
   }
 }

--- a/shared/src/main/scala/io/github/jam01/json_schema/SchemaValidator.scala
+++ b/shared/src/main/scala/io/github/jam01/json_schema/SchemaValidator.scala
@@ -71,7 +71,9 @@ final class BooleanObjValidator(bool: Boolean, ctx: Context, path: JsonPointer) 
 
 private class FFastObjectSchemaValidator[T](vocabs: Seq[Vocab[T]], ctx: Context, path: JsonPointer, dynParent: Option[Vocab[?]]) extends JsonVisitor[Seq[T], OutputUnit] {
   inline private def compose(units: Seq[OutputUnit]): OutputUnit = {
-    val result = ctx.ext.onScopeEnd(path, ctx.config.format.compose(path, units, ctx.instanceLoc))
+    // Root scope: insLoc is always Root, even if a mid-traversal `ffast` failure left the stack unbalanced.
+    val insLoc = if (dynParent.isEmpty) JsonPointer.Root else ctx.instanceLoc
+    val result = ctx.ext.onScopeEnd(path, ctx.config.format.compose(path, units, insLoc))
     if (dynParent.isEmpty && !result.vvalid) throw new ValidationException(result)
     result
   }

--- a/shared/src/main/scala/io/github/jam01/json_schema/package.scala
+++ b/shared/src/main/scala/io/github/jam01/json_schema/package.scala
@@ -10,8 +10,14 @@ package object json_schema {
 
   /**
    * Creates a validator visitor for the given schema and configuration.
-   * 
+   *
    * Visiting this validator results in the validation results for the visited structure.
+   *
+   * The returned visitor holds a mutable [[DefaultContext]] that tracks per-traversal state
+   * (instance location, annotation dependencies). It is **not thread-safe** — do not share a
+   * single visitor across threads. The same visitor may be reused for repeated sequential
+   * `.transform(...)` calls: the context is reset at the end of each top-level scope, so a
+   * `ValidationException` from a failed `ffast` transform does not corrupt the next call.
    *
    * @param schema the schema to apply
    * @param config validation configuration

--- a/shared/src/test/scala/io/github/jam01/json_schema/ValidatorReuseTest.scala
+++ b/shared/src/test/scala/io/github/jam01/json_schema/ValidatorReuseTest.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Jose Montoya
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.github.jam01.json_schema
+
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
+
+class ValidatorReuseTest {
+  private def mkValidator(schemaJson: String, cfg: Config = Config.Default) = {
+    val sch = ujson.Readable.fromString(schemaJson).transform(SchemaR())
+    validator(sch, cfg)
+  }
+
+  private def run(v: upickle.core.Visitor[?, OutputUnit], instance: ujson.Value): OutputUnit =
+    try instance.transform(v)
+    catch { case e: ValidationException => e.result }
+
+  // After a ffast failure on `[5, "bad"]`, the next transform must not see the leftover "1"
+  // instance-location token from the un-traversed remainder of the failed traversal.
+  @Test def ffast_failure_then_success_reports_correct_insloc(): Unit = {
+    val v = mkValidator("""{"type":"integer"}""", Config(format = OutputFormat.Basic, ffast = true))
+
+    val r1 = run(v, ujson.Str("nope"))
+    assertFalse(r1.vvalid, "first transform should fail")
+    assertEquals("", r1.insLoc.toString, "root failure should have root insLoc")
+
+    val r2 = run(v, ujson.Num(42))
+    assertTrue(r2.vvalid, "second transform should succeed on the reused validator")
+    assertEquals("", r2.insLoc.toString, "successful root result should have root insLoc")
+  }
+
+  @Test def ffast_failure_then_failure_reports_correct_insloc(): Unit = {
+    val v = mkValidator("""{"items":{"type":"integer"}}""", Config(format = OutputFormat.Basic, ffast = true))
+
+    val r1 = run(v, ujson.Arr(1, "bad", 3))
+    assertFalse(r1.vvalid)
+    assertEquals("", r1.insLoc.toString, "root unit of an array failure carries the root insLoc")
+
+    // Reused — failure on a fresh instance must not inherit the prior "/1" token.
+    val r2 = run(v, ujson.Arr("alpha"))
+    assertFalse(r2.vvalid)
+    assertEquals("", r2.insLoc.toString, "root unit of the second array failure must still be at root, not /1/0 or similar")
+  }
+
+  @Test def repeated_success_does_not_accumulate_annotations(): Unit = {
+    // unevaluatedProperties annotation collection would leak across transforms if the dependency
+    // maps weren't cleared between root scopes.
+    val v = mkValidator(
+      """{"properties":{"a":{"type":"integer"}},"unevaluatedProperties":false}""",
+      Config(format = OutputFormat.Basic, ffast = false, allowList = AllowList.KeepAll))
+
+    val r1 = run(v, ujson.Obj("a" -> 1))
+    assertTrue(r1.vvalid, "first transform should validate")
+
+    // If `dependents`/`dependencies` weren't reset, the second transform's `unevaluatedProperties`
+    // could observe stale annotation entries from the first.
+    val r2 = run(v, ujson.Obj("a" -> 2))
+    assertTrue(r2.vvalid, "second identical transform should also validate")
+
+    val r3 = run(v, ujson.Obj("a" -> 3, "extra" -> 4))
+    assertFalse(r3.vvalid, "third transform with an unevaluated property must fail")
+  }
+
+  @Test def non_ffast_reuse_works(): Unit = {
+    val v = mkValidator("""{"type":"integer"}""", Config(format = OutputFormat.Basic, ffast = false))
+
+    val r1 = run(v, ujson.Str("nope"))
+    assertFalse(r1.vvalid)
+
+    val r2 = run(v, ujson.Num(7))
+    assertTrue(r2.vvalid)
+  }
+}


### PR DESCRIPTION
Reset per-traversal Context state at the end of the root scope so the visitor returned by `validator(...)` can be reused across `.transform()` calls, including after `ValidationException` from a top-level `ffast` failure. Also stop pruning `dependents` per-scope (registrations are validator-lifetime) and pin the root unit's `insLoc` to `Root` even when an `ffast` failure interrupts traversal.

See docs/decisions/007-validator-reuse.md.