### PR TITLE
build: migrate publish to Sonatype Central Portal

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,55 +23,60 @@ jobs:
           cache: maven
           cache-dependency-path: '**/pom.yaml'
       - uses: mikefarah/yq@v4
-      - name: set release version
-        shell: bash
-        run: |
-          src/build/yq-assign.sh .version ${{ github.event.inputs.release_ver }} src/build/pom.yaml
-          src/build/yq-assign.sh .scm.tag ${{ github.event.inputs.release_ver }} src/build/pom.yaml
-          src/build/yq-assign.sh .parent.version ${{ github.event.inputs.release_ver }} jvm/pom.yaml
-          src/build/yq-assign.sh .parent.version ${{ github.event.inputs.release_ver }} js/pom.yaml
-      - name: install gpg key # see: https://gist.github.com/sualeh/ae78dc16123899d7942bc38baba5203c
-        run: |
-          cat <(echo -e "${{ secrets.GPG_KEY }}") | gpg --batch --import
-          gpg --list-secret-keys --keyid-format LONG
-      - name: mvn deploy
-        run: | # alt: mvn verify here and after git ops nexus:deploy -f mod/pom.yaml
-          mvn -V --no-transfer-progress --batch-mode --settings .mvn/settings.xml -Dmaven.install.skip=true -P release deploy
-        env:
-          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
       - name: config git # see: https://github.com/actions/checkout/issues/13#issuecomment-724415212
         # https://github.com/actions/checkout/tree/v4.1.7?tab=readme-ov-file#push-a-commit-using-the-built-in-token
         # alt: https://github.com/orgs/community/discussions/40405#discussioncomment-8361451
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: set release version
+        run: |
+          src/build/yq-assign.sh .version ${{ github.event.inputs.release_ver }} src/build/pom.yaml
+          src/build/yq-assign.sh .scm.tag ${{ github.event.inputs.release_ver }} src/build/pom.yaml
+          src/build/yq-assign.sh .parent.version ${{ github.event.inputs.release_ver }} jvm/pom.yaml
+          src/build/yq-assign.sh .parent.version ${{ github.event.inputs.release_ver }} js/pom.yaml
+
       - name: commit release
-        shell: bash
         run: |
           git add src/build/pom.yaml jvm/pom.yaml js/pom.yaml
           git commit -m "[ci skip] prepare release ${{ github.event.inputs.release_ver }}"
-          git push
+
       - name: tag release
-        shell: bash
+        run: git tag ${{ github.event.inputs.release_ver }} -m "[ci] release ${{ github.event.inputs.release_ver }}"
+
+      # see: https://gist.github.com/sualeh/ae78dc16123899d7942bc38baba5203c
+      - name: install gpg key
         run: |
-          git tag ${{ github.event.inputs.release_ver }} -m "[ci] release ${{ github.event.inputs.release_ver }}"
+          cat <(echo -e "${{ secrets.GPG_KEY }}") | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+
+      - name: mvn deploy
+        run: mvn -V --no-transfer-progress --batch-mode --settings .mvn/settings.xml -Dmaven.install.skip=true -P release deploy
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: push release commit and tag
+        run: |
+          git push origin HEAD
           git push origin ${{ github.event.inputs.release_ver }}
+
       - name: create gh release
-        shell: bash
         run: gh release create ${{ github.event.inputs.release_ver }} --generate-notes
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
       - name: set next dev version
-        shell: bash
         run: |
           src/build/yq-assign.sh .version ${{ github.event.inputs.next_ver }} src/build/pom.yaml
           src/build/yq-assign.sh .scm.tag HEAD src/build/pom.yaml
           src/build/yq-assign.sh .parent.version ${{ github.event.inputs.next_ver }} jvm/pom.yaml
           src/build/yq-assign.sh .parent.version ${{ github.event.inputs.next_ver }} js/pom.yaml
-      - name: commit next dev version
-        shell: bash
+
+      - name: commit and push next dev version
         run: |
           git add src/build/pom.yaml jvm/pom.yaml js/pom.yaml
           git commit -m "[ci skip] prepare for next development iteration"

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -4,9 +4,9 @@
     <!--https://issues.apache.org/jira/browse/MNG-5659-->
     <servers>
         <server>
-            <id>ossrh</id>
-            <username>${env.SONATYPE_USER}</username>
-            <password>${env.SONATYPE_PASSWORD}</password>
+            <id>central</id>
+            <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+            <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
         </server>
     </servers>
 </settings>

--- a/src/build/pom.yaml
+++ b/src/build/pom.yaml
@@ -29,20 +29,13 @@ scm: # Scm.html#set...
   developerConnection: scm:git:https://github.com/jam01/json-schema.git
   url: https://github.com/jam01/json-schema.git
   tag: HEAD
-distributionManagement:
-  snapshotRepository:
-    id: ossrh
-    url: https://s01.oss.sonatype.org/content/repositories/snapshots
-  repository:
-    id: ossrh
-    url: https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/
 
 properties:
   maven.compiler.source: '21'
   maven.compiler.target: '21'
   maven.compiler.release: '21'
   project.build.sourceEncoding: UTF-8
-  maven.deploy.skip: 'true' # in favor of nexus-staging
+  maven.deploy.skip: 'true' # in favor of central-publishing
   #polyglot.dump.pom: .generated-pom.xml # uncomment to check effective pom.xml
 
 build:
@@ -107,12 +100,8 @@ profiles:
               goals: ['sign'] # on verify
               configuration:
                 gpgArguments: ['--pinentry-mode', 'loopback']
-        - id: org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13
+        - id: org.sonatype.central:central-publishing-maven-plugin:0.10.0
           extensions: 'true'
-          executions:
-            - id: publish
-              goals: ['deploy'] # on deploy
           configuration:
-            serverId: ossrh
-            nexusUrl: https://s01.oss.sonatype.org
-            autoReleaseAfterClose: false
+            publishingServerId: central
+            autoPublish: false


### PR DESCRIPTION
Sonatype OSSRH was decommissioned in June 2025. Switch to the Central Publisher Portal via central-publishing-maven-plugin:0.10.0 and restructure the release workflow so the local commit and tag are only pushed after a successful deploy — failures leave the remote untouched.

- src/build/pom.yaml: drop distributionManagement; replace nexus-staging-maven-plugin with central-publishing-maven-plugin. autoPublish: false, so the staged release still needs a manual confirm on the Portal before going public.
- .mvn/settings.xml: server id 'ossrh' -> 'central'; env vars SONATYPE_USER/SONATYPE_PASSWORD -> MAVEN_CENTRAL_USERNAME/PASSWORD.
- .github/workflows/release.yaml: reorder to git config -> bump -> commit + tag (local) -> gpg -> deploy -> push commit + tag -> gh release -> bump next -> commit + push. Env vars updated to MAVEN_CENTRAL_USERNAME / MAVEN_CENTRAL_PASSWORD; needs matching GitHub Actions secrets.